### PR TITLE
Poprawiono warunek kolizji z przeszkodą (CS0019)

### DIFF
--- a/Snake.cs
+++ b/Snake.cs
@@ -215,7 +215,7 @@ namespace SnakeGame
 
                 //Hindernis treffen
 
-                if (hoofd.xPos == obstacleXpos /* ?? */ == obstacleYpos)
+                if (hoofd.xPos == obstacleXpos && hoofd.yPos == obstacleYpos)
 
                 {
 


### PR DESCRIPTION
Poprawiono warunek kolizji węża z przeszkodą poprzez rozdzielenie porównań współrzędnych X oraz Y i użycie operatora &&.

Fixes #9